### PR TITLE
Fixing to build with xCode 15.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.swiftpm/xcode/xcuserdata
 /.swiftpm/xcode/package.xcworkspace/xcuserdata
+/tmpDocs

--- a/Sources/RTVIClientIOSGeminiLiveWebSocket/GeminiLiveWebSocketConnection.swift
+++ b/Sources/RTVIClientIOSGeminiLiveWebSocket/GeminiLiveWebSocketConnection.swift
@@ -1,6 +1,17 @@
 import Foundation
 import RTVIClientIOS
 
+protocol GeminiLiveWebSocketConnectionDelegate: AnyObject {
+    func connectionDidFinishModelSetup(
+        _: GeminiLiveWebSocketConnection
+    )
+    func connection(
+        _: GeminiLiveWebSocketConnection,
+        didReceiveModelAudioBytes audioBytes: Data
+    )
+    func connectionDidDetectUserInterruption(_: GeminiLiveWebSocketConnection)
+}
+
 class GeminiLiveWebSocketConnection: NSObject, URLSessionWebSocketDelegate {
     
     // MARK: - Public
@@ -11,18 +22,7 @@ class GeminiLiveWebSocketConnection: NSObject, URLSessionWebSocketDelegate {
         let generationConfig: Value?
     }
     
-    protocol Delegate: AnyObject {
-        func connectionDidFinishModelSetup(
-            _: GeminiLiveWebSocketConnection
-        )
-        func connection(
-            _: GeminiLiveWebSocketConnection,
-            didReceiveModelAudioBytes audioBytes: Data
-        )
-        func connectionDidDetectUserInterruption(_: GeminiLiveWebSocketConnection)
-    }
-    
-    public weak var delegate: Delegate? = nil
+    public weak var delegate: GeminiLiveWebSocketConnectionDelegate? = nil
     
     init(options: Options) {
         self.options = options

--- a/Sources/RTVIClientIOSGeminiLiveWebSocket/GeminiLiveWebSocketTransport.swift
+++ b/Sources/RTVIClientIOSGeminiLiveWebSocket/GeminiLiveWebSocketTransport.swift
@@ -332,7 +332,7 @@ public class GeminiLiveWebSocketTransport: Transport {
 
 // MARK: - GeminiLiveWebSocketConnection.Delegate
 
-extension GeminiLiveWebSocketTransport: GeminiLiveWebSocketConnection.Delegate {
+extension GeminiLiveWebSocketTransport: GeminiLiveWebSocketConnectionDelegate {
     func connectionDidFinishModelSetup(_: GeminiLiveWebSocketConnection) {
         // If this happens *before* we've entered the connected state, first pass through that state
         if _state == .connecting {
@@ -364,7 +364,7 @@ extension GeminiLiveWebSocketTransport: GeminiLiveWebSocketConnection.Delegate {
 
 // MARK: - AudioPlayer.Delegate
 
-extension GeminiLiveWebSocketTransport: AudioPlayer.Delegate {
+extension GeminiLiveWebSocketTransport: AudioPlayerDelegate {
     func audioPlayerDidStartPlayback(_ audioPlayer: AudioPlayer) {
         delegate?.onBotStartedSpeaking(participant: connectedBotParticipant)
     }
@@ -380,7 +380,7 @@ extension GeminiLiveWebSocketTransport: AudioPlayer.Delegate {
 
 // MARK: - AudioRecorder.Delegate
 
-extension GeminiLiveWebSocketTransport: AudioRecorder.Delegate {
+extension GeminiLiveWebSocketTransport: AudioRecorderDelegate {
     func audioRecorder(_ audioPlayer: AudioRecorder, didGetAudioLevel audioLevel: Float) {
         delegate?.onUserAudioLevel(level: audioLevel)
     }

--- a/Sources/RTVIClientIOSGeminiLiveWebSocket/util/AudioPlayer.swift
+++ b/Sources/RTVIClientIOSGeminiLiveWebSocket/util/AudioPlayer.swift
@@ -1,16 +1,16 @@
 import AVFAudio
 
+protocol AudioPlayerDelegate: AnyObject {
+    func audioPlayerDidStartPlayback(_ audioPlayer: AudioPlayer)
+    func audioPlayerDidFinishPlayback(_ audioPlayer: AudioPlayer)
+    func audioPlayer(_ audioPlayer: AudioPlayer, didGetAudioLevel audioLevel: Float)
+}
+
 class AudioPlayer {
     
     // MARK: - Public
     
-    protocol Delegate: AnyObject {
-        func audioPlayerDidStartPlayback(_ audioPlayer: AudioPlayer)
-        func audioPlayerDidFinishPlayback(_ audioPlayer: AudioPlayer)
-        func audioPlayer(_ audioPlayer: AudioPlayer, didGetAudioLevel audioLevel: Float)
-    }
-    
-    public weak var delegate: Delegate? = nil
+    public weak var delegate: AudioPlayerDelegate? = nil
     
     init() {
         audioEngine = AVAudioEngine()

--- a/Sources/RTVIClientIOSGeminiLiveWebSocket/util/AudioRecorder.swift
+++ b/Sources/RTVIClientIOSGeminiLiveWebSocket/util/AudioRecorder.swift
@@ -1,14 +1,14 @@
 import AVFAudio
 
+protocol AudioRecorderDelegate: AnyObject {
+    func audioRecorder(_ audioPlayer: AudioRecorder, didGetAudioLevel audioLevel: Float)
+}
+
 class AudioRecorder {
 
     // MARK: - Public
     
-    protocol Delegate: AnyObject {
-        func audioRecorder(_ audioPlayer: AudioRecorder, didGetAudioLevel audioLevel: Float)
-    }
-    
-    public weak var delegate: Delegate? = nil
+    public weak var delegate: AudioRecorderDelegate? = nil
     
     var isRecording: Bool {
         audioEngine.isRunning

--- a/Tests/RTVIClientIOSGeminiLiveWebSocketTests/RTVIClientIOSGeminiLiveWebSocketTests.swift
+++ b/Tests/RTVIClientIOSGeminiLiveWebSocketTests/RTVIClientIOSGeminiLiveWebSocketTests.swift
@@ -1,5 +1,4 @@
 import XCTest
-@testable import RTVIClientIOSWSPrototype
 
 final class RTVIClientIOSGeminiLiveWebSocketTests: XCTestCase {
     func testExample() throws {


### PR DESCRIPTION
Fixing to build with xCode 15.2.

When trying to build with an old version of xCode we were receiving the following error:
`error: protocol 'Delegate' cannot be nested inside another declaration`

The same error as reported in [this thread](https://forums.swift.org/t/error-when-trying-to-follow-protocol-delegation-docs/70117). 