### PR TITLE
Make it so that when you disconnect a mic that you're not actively us…

### DIFF
--- a/Sources/PipecatClientIOSGeminiLiveWebSocket/util/AudioManager.swift
+++ b/Sources/PipecatClientIOSGeminiLiveWebSocket/util/AudioManager.swift
@@ -108,7 +108,7 @@ final class AudioManager {
         
         // Start polling for changes to available devices
         self.availableDevicesPollTimer = Timer.scheduledTimer(
-            withTimeInterval: 0.25,
+            withTimeInterval: 1,
             repeats: true
         ) { [weak self] _ in
             self?.refreshAvailableDevices()


### PR DESCRIPTION
…ing, we still detect a change in available mics.

We do that by polling for changes to available mics in addition to what we used to do, which was listen for route-change notifications. The latter mechanism would only fire on a mic disconnection if that mic had been in use (i.e. if it had been part of the active audio route). We're still keeping this mechanism in place since, when it works, it could theoretically result in more timely change detection than polling.

As part of implementing this change, I encapsulated the available-mics bookkeeping into AudioManager and out of its consumer (the transport). Without this, AudioManager would not know whether to fire its available-device-changed delegate on each poll, and the polling might as well have occurred in the transport itself. This didn't seem like a desirable architecture. By letting AudioManager encapsulate and manage more state, not less, we're setting ourselves up for porting this mic-disconnection-detection improvement in daily-ios, where it's also needed.

A next step will be to also encapsulate actual-mic-in-use bookkeeping in AudioManager, freeing the transport from doing yet another bit of bookkeeping.